### PR TITLE
Restful Refactor and View Restructure

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,5 @@
+class EventsController < ApplicationController
+  def show
+    @username = params[:username]
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,3 @@
 class PagesController < ApplicationController
   def index; end
-  def show;  end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @username %>'s GitHub Events!</h1>
+<label name="github-username" id="<%= @username %>" style="display:none;"></label>
+
+<div id="github-events">
+</div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -2,16 +2,7 @@
   <div class="row row-centered vcenter">
     <h3>Welcome to Gvents!</h3>
 
-    <%= form_tag event_path, method: :get do %>
-      <div class="form-group">
-        <div class="col-sm-4 col-centered">
-          <%= text_field_tag 'username', nil, class: 'form-control', id: 'myInput',
-                              placeholder: 'Enter your GitHub Username' %>
-        </div>
-      </div>
-
-      <%= submit_tag 'Submit', class: 'btn btn-default', name: nil %>
-    <% end %>
+    <%= render 'shared/events/username_submit_form' %>
   </div>
 </div>
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,14 +1,17 @@
 <div class="container">
   <div class="row row-centered vcenter">
     <h3>Welcome to Gvents!</h3>
-    <form onsubmit="location.href=window.location.href + document.getElementById('myInput').value; return false;" class="form-horizontal">
+
+    <%= form_tag event_path, method: :get do %>
       <div class="form-group">
         <div class="col-sm-4 col-centered">
-          <input type="text" id="myInput" class="form-control" placeholder="Enter your GitHub username" />
+          <%= text_field_tag 'username', nil, class: 'form-control', id: 'myInput',
+                              placeholder: 'Enter your GitHub Username' %>
         </div>
       </div>
-      <button type="submit" class="btn btn-default">Submit</button>
-    </form>
+
+      <%= submit_tag 'Submit', class: 'btn btn-default', name: nil %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,5 +1,0 @@
-<h1><%= params[:id] %>'s GitHub Events!</h1>
-<label name="github-username" id="<%= params[:id] %>" style="display:none;"></label>
-
-<div id="github-events">
-</div>

--- a/app/views/shared/events/_username_submit_form.html.erb
+++ b/app/views/shared/events/_username_submit_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_tag event_path, method: :get do %>
+  <div class="form-group">
+    <div class="col-sm-4 col-centered">
+      <%= text_field_tag 'username', nil, class: 'form-control', id: 'myInput',
+                          placeholder: 'Enter your GitHub Username' %>
+    </div>
+  </div>
+
+  <%= submit_tag 'Submit', class: 'btn btn-default', name: nil %>
+<% end %>

--- a/app/views/shared/events/_username_submit_form.html.erb
+++ b/app/views/shared/events/_username_submit_form.html.erb
@@ -1,8 +1,9 @@
 <%= form_tag event_path, method: :get do %>
   <div class="form-group">
     <div class="col-sm-4 col-centered">
-      <%= text_field_tag 'username', nil, class: 'form-control', id: 'myInput',
-                          placeholder: 'Enter your GitHub Username' %>
+      <%= text_field_tag 'username', nil,
+        class: 'form-control', id: 'myInput', required: true,
+        placeholder: 'Enter your GitHub Username' %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root 'pages#index'
-  get  '/:id', to: 'pages#show'
+
+  resource :event, only: :show
 end


### PR DESCRIPTION
This PR builds on previous code from @awaxman11 - well done!

These changes make the application more RESTFUL and prevent a direct, 'open' route of /:id to the application. Now, a GET request must be done from the main index page via the form, which requires user input.

Here are the actions I took:
- Moved (GitHub) events specific code to EventsController and added appropriate route.
- Changed literal <form> declarations to using form_helpers provided by Rails.
- Moved new form into its own partial for later use.

Additional things we will want to do _in React_ code is verify whether GitHub username is valid based on the API calls we make. That can all be done in JavaScript and not in Rails.
